### PR TITLE
macOSでも動くように調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.2",
     "@types/chrome": "^0.0.127",
+    "bowser": "^2.11.0",
     "material-ui-color-picker": "^3.5.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "simpleGestures",
-	"version": "1.3.2",
+	"version": "1.4.0",
 	"manifest_version": 2,
 	"description": "simple mouse gestures.",
 	"icons": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "typeRoots": ["node_modules/@types"],
     "sourceMap": true,
     "allowJs": true,
+    "esModuleInterop": true,
     "lib": [
       "dom",
       "es5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,6 +1891,11 @@ bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Mac OSではコンテキストメニューが右クリックのマウスダウン時に発生してしまう。
そのため、ジェスチャのあり/なしでのメニュー制御ができないため、右のダブルクリックでメニューが表示されるよう変更した。