### PR TITLE
fix: #76, #80 fix-open-new-link

### DIFF
--- a/src/js/app/mouse.ts
+++ b/src/js/app/mouse.ts
@@ -43,15 +43,16 @@ class Mouse {
    */
   static getHref(mouseevent: HTMLElementEvent<HTMLChildElement>): null|string {
     const target: HTMLChildElement = mouseevent.target;
-    const parent: HTMLLinkElement = target.parentElement;
+    const parentLinkElement = target.closest('a');
 
     if (target.href) {
       return target.href;
     }
 
-    if (parent && parent.href) {
-      return parent.href;
+    if (parentLinkElement && parentLinkElement.href) {
+      return parentLinkElement.href;
     }
+
     return null;
   }
 


### PR DESCRIPTION
resolve: #76, #80

マウスイベントを発生した要素が、aリンクのネストされた子孫だった場合に、Aリンクまで辿れずにURLが取得出来ていなかった。Element.closestで先祖を検索するようにして修正