### PR TITLE
設定リセット時に、ジェスチャー設定の表示がリセット前のままになっていたのを修正

### DIFF
--- a/src/js/app/lib_option.ts
+++ b/src/js/app/lib_option.ts
@@ -80,13 +80,12 @@ class LibOption {
 
 
   /**
-   *
-   * @return {undefined}
+   * 設定のリセット
    */
-  reset(): void {
+  async reset(): Promise<void> {
     this.storage.clear();
 
-    this.load().then();
+    await this.load();
   }
 
   /**

--- a/src/options_page/options_page.js
+++ b/src/options_page/options_page.js
@@ -331,10 +331,10 @@ const registerEventForGesture = () => {
 };
 
 const registerEventForAllReset = () => {
-  $('#reset_all').on('click', () => {
+  $('#reset_all').on('click', async () => {
     const confirmOk = window.confirm(lang.confirmOptionReset[option.getLanguage()]);
     if (confirmOk) {
-      option.reset();
+      await option.reset();
 
       reflectOptionSettingsOnScreen();
       reflectSelectedLanguageToScreen();


### PR DESCRIPTION
設定データは消えていたが、表示だけ元のまま変わっていなかった