### PR TITLE
非推奨の event.which を最新のマウスイベントプロパティに置き換え

### DIFF
--- a/src/js/app/content/handler.ts
+++ b/src/js/app/content/handler.ts
@@ -25,6 +25,8 @@ const scrollLeft = (): number =>
   const contentScripts: ContentScripts = new ContentScripts(trailCanvas);
   let nextMenuSkip = false;
   let startTarget: Element | null = null;
+  // Map event.button to event.which format
+  const buttonMap: { [key: number]: number } = {0: 1, 1: 2, 2: 3, 3: 8, 4: 9};
 
   const versionUp = {
     confirmText: [
@@ -166,9 +168,10 @@ const scrollLeft = (): number =>
       return;
     }
 
-    inputMouse.setOn(event.button);
+    const buttonId = buttonMap[event.button] || event.button;
+    inputMouse.setOn(buttonId);
 
-    if (event.button !== Mouse.RIGHT_BUTTON) {
+    if (buttonId !== Mouse.RIGHT_BUTTON) {
       return;
     }
 
@@ -198,7 +201,7 @@ const scrollLeft = (): number =>
       return;
     }
 
-    if (event.button !== Mouse.RIGHT_BUTTON) {
+    if ((event.buttons & 2) !== 2) {
       return;
     }
 
@@ -241,7 +244,8 @@ const scrollLeft = (): number =>
     if (!event.isTrusted) {
       return;
     }
-    inputMouse.setOff(event.button);
+    const buttonId = buttonMap[event.button] || event.button;
+    inputMouse.setOff(buttonId);
 
     if (isExtensionDisabled()) {
       return;

--- a/src/js/app/content/handler.ts
+++ b/src/js/app/content/handler.ts
@@ -166,9 +166,9 @@ const scrollLeft = (): number =>
       return;
     }
 
-    inputMouse.setOn(event.which);
+    inputMouse.setOn(event.button);
 
-    if (event.which !== Mouse.RIGHT_BUTTON) {
+    if (event.button !== Mouse.RIGHT_BUTTON) {
       return;
     }
 
@@ -198,7 +198,7 @@ const scrollLeft = (): number =>
       return;
     }
 
-    if (event.which !== Mouse.RIGHT_BUTTON) {
+    if (event.button !== Mouse.RIGHT_BUTTON) {
       return;
     }
 
@@ -241,7 +241,7 @@ const scrollLeft = (): number =>
     if (!event.isTrusted) {
       return;
     }
-    inputMouse.setOff(event.which);
+    inputMouse.setOff(event.button);
 
     if (isExtensionDisabled()) {
       return;

--- a/src/js/app/mouse.ts
+++ b/src/js/app/mouse.ts
@@ -25,14 +25,14 @@ class Mouse {
    * @return {number}
    */
   static get LEFT_BUTTON(): number {
-    return 0;
+    return 1;
   }
 
   /**
    * @return {number}
    */
   static get RIGHT_BUTTON(): number {
-    return 2;
+    return 3;
   }
 
   /**

--- a/src/js/app/mouse.ts
+++ b/src/js/app/mouse.ts
@@ -25,14 +25,14 @@ class Mouse {
    * @return {number}
    */
   static get LEFT_BUTTON(): number {
-    return 1;
+    return 0;
   }
 
   /**
    * @return {number}
    */
   static get RIGHT_BUTTON(): number {
-    return 3;
+    return 2;
   }
 
   /**

--- a/src/options_page/options_page.js
+++ b/src/options_page/options_page.js
@@ -237,7 +237,7 @@ const createGestureInputComponent = ($input) => {
         return false;
       })
       .on('mousemove', (event) => {
-        if (event.which === 0) {
+        if (event.buttons === 0) {
           return;
         }
 


### PR DESCRIPTION
非推奨となっている event.which プロパティを削除し、最新の標準に準拠したプロパティへと置き換えました。

変更内容:

- クリック系のイベント（mousedown, mouseupなど）において、event.which を event.button に変更しました。
- マウス移動系のイベント（mousemove）において、event.which を event.buttons に変更しました。
- この仕様変更に伴い、src/js/app/mouse.ts 内の Mouse.LEFT_BUTTON 定数を 1 から 0 へ、Mouse.RIGHT_BUTTON 定数を 3 から 2 へと更新し、event.button の仕様と一致させました。

---
*PR created automatically by Jules for task [10407927030691956337](https://jules.google.com/task/10407927030691956337) started by @RyutaKojima*