### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS risk by replacing innerHTML with textContent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
 ## 2024-11-20 - [XSS Fix] Replace innerHTML with textContent
-**Vulnerability:** innerHTML was being used to render action and command names to the DOM, presenting a risk of XSS if inputs weren't explicitly sanitized.
-**Learning:** In a chrome extension rendering a small content script overlay, innerHTML should be strictly avoided in favor of textContent for textual variables to prevent any DOM-based script injection.
-**Prevention:** We should always use textContent instead of innerHTML when printing dynamic data to elements, effectively rendering input safely.
+**Vulnerability:** actionやcommandの名前をDOMに描画する際にinnerHTMLが使用されており、入力が明示的にサニタイズされていない場合、XSSのリスクが存在していた。
+**Learning:** 小さなコンテンツスクリプトのオーバーレイを描画するChrome拡張機能において、テキスト変数に対してはinnerHTMLの使用を厳密に避け、DOMベースのスクリプトインジェクションを防ぐためにtextContentを採用すべきである。
+**Prevention:** 動的なデータを要素に出力する際は、常に入力を安全にレンダリングするtextContentをinnerHTMLの代わりに使用すべきである。

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - [XSS Fix] Replace innerHTML with textContent
+**Vulnerability:** innerHTML was being used to render action and command names to the DOM, presenting a risk of XSS if inputs weren't explicitly sanitized.
+**Learning:** In a chrome extension rendering a small content script overlay, innerHTML should be strictly avoided in favor of textContent for textual variables to prevent any DOM-based script injection.
+**Prevention:** We should always use textContent instead of innerHTML when printing dynamic data to elements, effectively rendering input safely.

--- a/src/js/app/content/content_scripts.ts
+++ b/src/js/app/content/content_scripts.ts
@@ -173,16 +173,16 @@ class ContentScripts {
 
     const divAction = document.getElementById(this.actionNameDiv.id);
     if (this.option.isActionTextOn()) {
-      divAction.innerHTML = actionName ? actionName : '';
+      divAction.textContent = actionName ? actionName : '';
     } else {
-      divAction.innerHTML = '';
+      divAction.textContent = '';
     }
 
     const divCommand = document.getElementById(this.commandDiv.id);
     if (this.option.isCommandTextOn()) {
-      divCommand.innerHTML = commandName;
+      divCommand.textContent = commandName;
     } else {
-      divCommand.innerHTML = '';
+      divCommand.textContent = '';
     }
   }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used `innerHTML` to set dynamically retrieved strings (`commandName` and `actionName`) into the extension's DOM elements overlay.
🎯 Impact: Using `innerHTML` opens up a vector for DOM-based Cross-Site Scripting (XSS) if the data can be maliciously crafted or untrusted.
🔧 Fix: Replaced `innerHTML` with `textContent` which strictly sets plain text, natively escaping all markup tags before injecting into the DOM.
✅ Verification: Tested against standard build, lint, and test scripts in repo. Checked that DOM still properly renders labels with safe `textContent` logic.

---
*PR created automatically by Jules for task [10926759351025217754](https://jules.google.com/task/10926759351025217754) started by @RyutaKojima*