### PR TITLE
🛡️ Sentinel: [HIGH] Fix unsafe URL schemes in Mouse.getHref

### DIFF
--- a/src/js/app/mouse.test.ts
+++ b/src/js/app/mouse.test.ts
@@ -1,0 +1,56 @@
+import Mouse, { HTMLChildElement, HTMLElementEvent } from './mouse';
+
+describe('Mouse', () => {
+  describe('getHref', () => {
+    const createMockEvent = (
+      targetHref?: string,
+      parentHref?: string,
+    ): HTMLElementEvent<HTMLChildElement> => {
+      const parentLink = parentHref
+        ? ({ href: parentHref } as unknown as HTMLLinkElement)
+        : null;
+
+      const target = {
+        closest: (selector: string) => (selector === 'a' ? parentLink : null),
+        href: targetHref || '',
+      } as unknown as HTMLChildElement;
+
+      return { target } as unknown as HTMLElementEvent<HTMLChildElement>;
+    };
+
+    it('returns http URLs', () => {
+      const event = createMockEvent('http://example.com/test');
+      expect(Mouse.getHref(event)).toBe('http://example.com/test');
+    });
+
+    it('returns https URLs', () => {
+      const event = createMockEvent('https://example.com/test');
+      expect(Mouse.getHref(event)).toBe('https://example.com/test');
+    });
+
+    it('returns http URLs from parent <a> element', () => {
+      const event = createMockEvent('', 'https://example.com/parent');
+      expect(Mouse.getHref(event)).toBe('https://example.com/parent');
+    });
+
+    it('rejects javascript: URLs (prevents XSS)', () => {
+      const event = createMockEvent('javascript:alert(1)');
+      expect(Mouse.getHref(event)).toBeNull();
+    });
+
+    it('rejects data: URLs', () => {
+      const event = createMockEvent('data:text/html,<script>alert(1)</script>');
+      expect(Mouse.getHref(event)).toBeNull();
+    });
+
+    it('rejects file: URLs', () => {
+      const event = createMockEvent('file:///etc/passwd');
+      expect(Mouse.getHref(event)).toBeNull();
+    });
+
+    it('returns null when no href is present', () => {
+      const event = createMockEvent('');
+      expect(Mouse.getHref(event)).toBeNull();
+    });
+  });
+});

--- a/src/js/app/mouse.ts
+++ b/src/js/app/mouse.ts
@@ -45,12 +45,24 @@ class Mouse {
     const target: HTMLChildElement = mouseevent.target;
     const parentLinkElement = target.closest('a');
 
+    let rawHref: string | null = null;
     if (target.href) {
-      return target.href;
+      rawHref = target.href;
+    } else if (parentLinkElement && parentLinkElement.href) {
+      rawHref = parentLinkElement.href;
     }
 
-    if (parentLinkElement && parentLinkElement.href) {
-      return parentLinkElement.href;
+    if (!rawHref) {
+      return null;
+    }
+
+    try {
+      const parsedUrl = new URL(rawHref);
+      if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+        return rawHref;
+      }
+    } catch {
+      // Invalid URL
     }
 
     return null;


### PR DESCRIPTION
### 🚨 Severity: HIGH

### 💡 Vulnerability
`Mouse.getHref` において、`a` タグや要素の `href` 属性を検証せずにそのまま取得してバックグラウンドスクリプト（`chrome.tabs.create` 等）へ渡していました。これにより、悪意のあるページやコンテンツに `javascript:` や `data:` などの危険なスキームを含むリンクが含まれていた場合、スクリプト実行や予期せぬ権限昇格・ローカルファイルアクセスにつながる脆弱性が存在していました。

### 🎯 Impact
リンクを対象としたジェスチャー操作（新しいタブで開く等）において、`javascript:` スキーム等が実行されたり、特権的コンテキストで予期せぬアクションが発生するリスクを回避します。

### 🔧 Fix
`Mouse.getHref` にて、URLをパースし、プロトコルが `http:` または `https:` の場合にのみ URL 文字列を返すように入力検証・サニタイズ処理を追加しました。

### ✅ Verification
1. `src/js/app/mouse.test.ts` を追加し、`http:` および `https:` の正常な URL が取得できること、および `javascript:`, `data:`, `file:` 等の危険なプロトコルが適切に除外（`null` 返却）されることをテストしました。
2. `yarn test`（Jest）、`yarn lint:all`（TypeScript, ESLint, Stylelint）、`yarn build` を全て実行し、エラーなくパスすることを確認しました。

---
*PR created automatically by Jules for task [1539260422956907674](https://jules.google.com/task/1539260422956907674) started by @RyutaKojima*