### PR TITLE
CodeQL CIワークフローの言語マトリクス設定の修復

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,8 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        language: [ 'javascript-typescript' ]
+        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:


### PR DESCRIPTION
`.github/workflows/codeql-analysis.yml` において CodeQL の言語指定が旧表記の `javascript` となっていたため、GitHub Actions / CodeQL v4 で推奨される `javascript-typescript` へ修正しました。

---
*PR created automatically by Jules for task [6517770461578319688](https://jules.google.com/task/6517770461578319688) started by @RyutaKojima*